### PR TITLE
Lazy settings load

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,11 @@ Available for testing
 
 Use `pip install git+https://github.com/drgarcia1986/simple-settings.git` to test this features
 
+* Lazy settings load.
+
 Read the [documentation](http://simple-settings.readthedocs.org/en/latest/) for more informations.
 
 Next versions
 -------------
 * Read settings from _yaml_ files.
 * Read settings from remote files.
-* Lazy load.

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,8 +164,11 @@ assert settings.SOME_SETTING == 'bar'
 ```
 
 ## Changelog
+### [NEXT_RELEASE]
+* Lazy settings load.
+
 ### [0.3.1] - 2015-07-23
-* Avoid to load python modules (as settings) in python files (with this, fix `deepcopy` bug in `as_dict()` method)
+* Avoid to load python modules (as settings) in python files (with this, fix `deepcopy` bug in `as_dict()` method).
 
 ### [0.3.0] - 2015-07-19
 * Deepcopy in `as_dict` method to anticipate unexpected changes.

--- a/examples/simple/app.py
+++ b/examples/simple/app.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import os
+
 from simple_settings import settings
 
 
+os.environ.setdefault('settings', 'project_settings')
 print settings.SIMPLE_CONF

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -13,7 +13,7 @@ class _Settings(object):
     def __init__(self):
         self._dict = {}
         self._settings_list = []
-        self._setup()
+        self._initialized = False
 
     def _get_settings_from_cmd_line(self):
         for arg in sys.argv[1:]:
@@ -24,6 +24,9 @@ class _Settings(object):
                     return
 
     def _setup(self):
+        if self._initialized:
+            return
+
         settings_value = self._get_settings_from_cmd_line()
         if not settings_value:
             settings_value = os.environ.get('settings')
@@ -33,6 +36,8 @@ class _Settings(object):
         self._settings_list = settings_value.split(',')
         self._load_settings_pipeline()
         self._process_special_settings()
+
+        self._initialized = True
 
     def _override_settings_by_env(self):
         for key, value in self._dict.items():
@@ -76,12 +81,14 @@ class _Settings(object):
         raise RuntimeError('Invalid settings file [{}]'.format(settings_file))
 
     def __getattr__(self, attr):
+        self._setup()
         try:
             return self._dict[attr]
         except KeyError:
             raise AttributeError('You do not set {} setting'.format(attr))
 
     def as_dict(self):
+        self._setup()
         return deepcopy(self._dict)
 
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -1,18 +1,9 @@
 # -*- coding: utf-8 -*-
-import copy
+from copy import deepcopy
 import os
 import sys
 
 from .strategies import strategies
-
-
-def _get_settings_from_cmd_line():
-    for arg in sys.argv[1:]:
-        if arg.startswith('--settings'):
-            try:
-                return arg.split('=')[1]
-            except IndexError:
-                return None
 
 
 class _Settings(object):
@@ -24,8 +15,16 @@ class _Settings(object):
         self._settings_list = []
         self._setup()
 
+    def _get_settings_from_cmd_line(self):
+        for arg in sys.argv[1:]:
+            if arg.startswith('--settings'):
+                try:
+                    return arg.split('=')[1]
+                except IndexError:
+                    return
+
     def _setup(self):
-        settings_value = _get_settings_from_cmd_line()
+        settings_value = self._get_settings_from_cmd_line()
         if not settings_value:
             settings_value = os.environ.get('settings')
         if not settings_value:
@@ -44,7 +43,7 @@ class _Settings(object):
             self._dict[self.SPECIAL_SETTINGS_KEY]['REQUIRED_SETTINGS']
         )
         invalid_settings_list = [
-            i for i in required_settings if not self._dict.get(i)
+            i for i in required_settings if i not in self._dict
         ]
         if invalid_settings_list:
             raise ValueError(
@@ -54,10 +53,9 @@ class _Settings(object):
             )
 
     def _process_special_settings(self):
-        if self.SPECIAL_SETTINGS_KEY not in self._dict:
+        special_settings = self._dict.get(self.SPECIAL_SETTINGS_KEY)
+        if not special_settings:
             return
-
-        special_settings = self._dict[self.SPECIAL_SETTINGS_KEY]
 
         if special_settings.get('OVERRIDE_BY_ENV'):
             self._override_settings_by_env()
@@ -68,10 +66,6 @@ class _Settings(object):
     def _load_settings_pipeline(self):
         for settings_file in self._settings_list:
             strategy = self._get_strategy_by_file(settings_file)
-            if not strategy:
-                raise RuntimeError(
-                    'Invalid settings file [{}]'.format(settings_file)
-                )
             settings = strategy.load_settings_file(settings_file)
             self._dict.update(settings)
 
@@ -79,14 +73,16 @@ class _Settings(object):
         for strategy in strategies:
             if strategy.is_valid_file(settings_file):
                 return strategy
+        raise RuntimeError('Invalid settings file [{}]'.format(settings_file))
 
     def __getattr__(self, attr):
-        if attr not in self._dict:
+        try:
+            return self._dict[attr]
+        except KeyError:
             raise AttributeError('You do not set {} setting'.format(attr))
-        return self._dict[attr]
 
     def as_dict(self):
-        return copy.deepcopy(self._dict)
+        return deepcopy(self._dict)
 
 
 settings = _Settings()

--- a/simple_settings/utils.py
+++ b/simple_settings/utils.py
@@ -23,6 +23,7 @@ class settings_stub(object):
         return inner
 
     def __enter__(self):
+        settings._setup()
         for key, value in self.new_settings.items():
             if key not in settings._dict:
                 raise ValueError(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,39 +4,55 @@ import sys
 from mock import patch
 import pytest
 
+from simple_settings import settings
+from simple_settings.utils import settings_stub
+
 
 class TestSettingsUtils(object):
 
-    def setup(self):
+    @pytest.yield_fixture
+    def current_settings(self):
         with patch.object(
             sys, 'argv', ['', '--settings=tests.samples.simple']
         ):
-            from simple_settings import settings
-            self.current_settings = settings
+            settings._setup()
+        yield settings
+        self._clean_simple_settings()
 
-        from simple_settings.utils import settings_stub
-        self.settings_stub = settings_stub
+    def _clean_simple_settings(self):
+        settings._initialized = False
+        settings._dict = {}
+        settings._settings_list = []
 
-    def teardown(self):
-        self.current_settings = None
+    def test_stub_settings_with_context_manager(self, current_settings):
+        with settings_stub(SIMPLE_STRING='stubed'):
+            assert current_settings.SIMPLE_STRING == 'stubed'
 
-    def test_stub_settings_with_context_manager(self):
-        with self.settings_stub(SIMPLE_STRING='stubed'):
-            assert self.current_settings.SIMPLE_STRING == 'stubed'
+        assert current_settings.SIMPLE_STRING == 'simple'
 
-        assert self.current_settings.SIMPLE_STRING == 'simple'
-
-    def test_stub_settings_with_decorator(self):
-        @self.settings_stub(SIMPLE_STRING='stubed')
+    def test_stub_settings_with_decorator(self, current_settings):
+        @settings_stub(SIMPLE_STRING='stubed')
         def get_simple_string_from_setting():
-            return self.current_settings.SIMPLE_STRING
+            return current_settings.SIMPLE_STRING
 
         assert get_simple_string_from_setting() == 'stubed'
-        assert self.current_settings.SIMPLE_STRING == 'simple'
+        assert current_settings.SIMPLE_STRING == 'simple'
 
-    def test_stub_settings_should_raise_value_error_from_a_wrong_settings(self):  # noqa
+    def test_stub_settings_should_raise_value_error_from_a_wrong_settings(
+        self, current_settings
+    ):
         with pytest.raises(ValueError) as exc:
-            with self.settings_stub(WRONG_SETTING='ops'):
+            with settings_stub(WRONG_SETTING='ops'):
                 pass
 
         assert 'WRONG_SETTING' in str(exc)
+
+    def test_stub_settings_shoud_setup_lazy_settings_object(self):
+        with patch.object(
+            sys, 'argv', ['', '--settings=tests.samples.simple']
+        ):
+            with settings_stub(SIMPLE_STRING='stubed'):
+                assert settings.SIMPLE_STRING == 'stubed'
+
+        assert settings.SIMPLE_STRING == 'simple'
+        self._clean_simple_settings()


### PR DESCRIPTION
The main settings singleton object (`from simple_settings import settings`) now working with lazy load.

```python
from simple_settings import settings  # don't load settings files

settings.FOO  #  load settings file
```
And with this change is possible to use `os.environ.setdefault` method to set settings files:

```bash
$ tree . 
.
├── app.py
├── project_settings.py
```
```bash
$ python app.py
simple
```
```python
# project_settings.py
SIMPLE_CONF = 'simple'
```
```python
# app.py
import os
from simple_settings import settings

os.environ.setdefault('settings', 'project_settings')
print settings.SIMPLE_CONF
```