### PR TITLE
Add test to prove configure on unaccessed settings doesn't work

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -211,3 +211,10 @@ class TestSettings(object):
             settings.SIMPLE_STRING
 
         assert not mock.called
+
+    def test_should_override_a_setting_without_accessing_it_first(self):
+        expect_module = 'tests.samples.simple'
+        settings = LazySettings(expect_module)
+
+        settings.configure(SIMPLE_STRING='overridden')
+        assert settings.SIMPLE_STRING == 'overridden'


### PR DESCRIPTION
Currently `settings.configure()` only works if the value has been previously accessed as proven by `tests.test_settings.TestSettings#test_should_configure_settings_with_new_values`, however if the value has never been accessed, then the value doesn't apply.