### PR TITLE
Support configuring dynamic backends with an optional prefix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -160,7 +160,7 @@ SIMPLE_SETTINGS = {
     'REQUIRED_SETTINGS': ('API_TOKEN', 'DB_USER'),
     'DYNAMIC_SETTINGS': {
         'backend': 'redis',
-        'pattern': 'MYAPP_DYNAMIC_*',
+        'pattern': 'DYNAMIC_*',
         'auto_casting': True,
         'prefix': 'MYAPP_'
     }
@@ -194,7 +194,7 @@ The current dynamic mechanisms suported is:
 For all _dynamic settings_ backends _simple-settings_ accept this optional parameters:
 
 * `pattern`: if you set some regex pattern the dynamic settings reader only get settings that match with this pattern. (Note
-that any configured prefix will be prepended before key is checked against pattern.)
+that the pattern will be applied to key as entered, ignoring any configured `prefix` setting.)
 * `auto_casting`: if you set this conf to `True` (default is `False`) _simple settings_ use
 [jsonpickle](https://github.com/jsonpickle/jsonpickle) to encode settings value before save in dynamic storage
 and decode after read from dynamic storage. With this bahavior you can use complex types (like _dict_ and _list_)
@@ -202,7 +202,6 @@ in dynamic settings.
 * `prefix`: if you set a prefix this value will be prepended to the keys when looked up on the backend.  The value is
 prepended without any interpretation, so the key `key="MYKEY" and prefix="my/namespace/"` would resolve to
 `key="my/namespace/MYKEY"` and `key="MYKEY" and prefix="MY_NAMESPACE_"` would resolve to `key="MY_NAMESPACE_MYKEY"`.
-Some backends may implement a default `pattern` to prevent setting invalid prefixes.
 
 #### Redis
 You can read your settings dynamically in redis if you activate the `DYNAMIC_SETTINGS` special setting with `redis` backend:

--- a/docs/index.md
+++ b/docs/index.md
@@ -223,13 +223,14 @@ SIMPLE_SETTINGS = {
     'DYNAMIC_SETTINGS': {
         'backend': 'consul',
         'host': 'locahost',
-        'port': 8500
+        'port': 8500,
+        'prefix': 'mynamespace/'      # Prefixes all key requests in consul with this value
     }
 }
 ```
 > for `consul` backend `localhost` is default value for `host` and `8500` is the default value for `port`.
 
-Additional attributes for consul backend: `datacenter`, `token`, `scheme`
+Additional attributes for consul backend: `datacenter`, `token`, `scheme`.
 
 > To install with consul dependencies use: `pip install simple-settings[consul]`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,8 +160,9 @@ SIMPLE_SETTINGS = {
     'REQUIRED_SETTINGS': ('API_TOKEN', 'DB_USER'),
     'DYNAMIC_SETTINGS': {
         'backend': 'redis',
-        'pattern': 'DYNAMIC_*',
-        'auto_casting': True
+        'pattern': 'MYAPP_DYNAMIC_*',
+        'auto_casting': True,
+        'prefix': 'MYAPP_'
     }
 }
 ```
@@ -192,11 +193,16 @@ The current dynamic mechanisms suported is:
 #### Default Dynamic Settings Configuration
 For all _dynamic settings_ backends _simple-settings_ accept this optional parameters:
 
-* `pattern`: if you set some pattern the dynamic settings reader only get settings that match with this pattern.
+* `pattern`: if you set some regex pattern the dynamic settings reader only get settings that match with this pattern. (Note
+that any configured prefix will be prepended before key is checked against pattern.)
 * `auto_casting`: if you set this conf to `True` (default is `False`) _simple settings_ use
 [jsonpickle](https://github.com/jsonpickle/jsonpickle) to encode settings value before save in dynamic storage
 and decode after read from dynamic storage. With this bahavior you can use complex types (like _dict_ and _list_)
 in dynamic settings.
+* `prefix`: if you set a prefix this value will be prepended to the keys when looked up on the backend.  The value is
+prepended without any interpretation, so the key `key="MYKEY" and prefix="my/namespace/"` would resolve to
+`key="my/namespace/MYKEY"` and `key="MYKEY" and prefix="MY_NAMESPACE_"` would resolve to `key="MY_NAMESPACE_MYKEY"`.
+Some backends may implement a default `pattern` to prevent setting invalid prefixes.
 
 #### Redis
 You can read your settings dynamically in redis if you activate the `DYNAMIC_SETTINGS` special setting with `redis` backend:
@@ -224,7 +230,7 @@ SIMPLE_SETTINGS = {
         'backend': 'consul',
         'host': 'locahost',
         'port': 8500,
-        'prefix': 'mynamespace/'      # Prefixes all key requests in consul with this value
+        'prefix': 'mynamespace/'
     }
 }
 ```
@@ -280,6 +286,10 @@ assert settings.SOME_SETTING == 'bar'
 ```
 
 ## Changelog
+
+### [NEXT_RELEASE]
+* Support configuring dynamic backends with an optional _prefix_.
+
 ### [0.9.1] - 2016-09-15
 * `configure` method now works even called before the LazySettings setup.
 

--- a/simple_settings/dynamic_settings/base.py
+++ b/simple_settings/dynamic_settings/base.py
@@ -45,4 +45,5 @@ class BaseReader(object):
         :param key: The unprefixed key.
         :return: The key with any configured prefix prepended.
         """
-        return '{}{}'.format(self.key_prefix if self.key_prefix is not None else '', key)
+        pfx = self.key_prefix if self.key_prefix is not None else ''
+        return '{}{}'.format(pfx, key)

--- a/simple_settings/dynamic_settings/base.py
+++ b/simple_settings/dynamic_settings/base.py
@@ -16,11 +16,12 @@ class BaseReader(object):
         self.conf.update(conf)
         self.key_pattern = self.conf.get('pattern')
         self.auto_casting = self.conf.get('auto_casting')
+        self.key_prefix = self.conf.get('prefix')
 
     def get(self, key):
         if not self._is_valid_key(key):
             return
-        result = self._get(key)
+        result = self._get(self._qualified_key(key))
         if self.auto_casting:
             result = jsonpickle.decode(result)
         return result
@@ -30,9 +31,18 @@ class BaseReader(object):
             return
         if self.auto_casting:
             value = jsonpickle.encode(value)
-        self._set(key, value)
+        self._set(self._qualified_key(key), value)
 
     def _is_valid_key(self, key):
         if not self.key_pattern:
             return True
         return bool(re.match(self.key_pattern, key))
+
+    def _qualified_key(self, key):
+        """
+        Prepends the configured prefix to the key (if applicable).
+
+        :param key: The unprefixed key.
+        :return: The key with any configured prefix prepended.
+        """
+        return '{}{}'.format(self.key_prefix if self.key_prefix is not None else '', key)

--- a/simple_settings/dynamic_settings/consul_reader.py
+++ b/simple_settings/dynamic_settings/consul_reader.py
@@ -21,7 +21,6 @@ class Reader(BaseReader):
         'host': consulate.DEFAULT_HOST,
         'port': consulate.DEFAULT_PORT,
         'scheme': consulate.DEFAULT_SCHEME,
-        'prefix': ''
     }
 
     def __init__(self, conf):
@@ -35,24 +34,23 @@ class Reader(BaseReader):
             scheme=self.conf['scheme']
         )
 
-    def _qualified_key(self, key):
-        """
-        Prepends the prefix to the key (if applicable).
-
-        :param key: The unprefixed key.
-        :return: The qualifeid key.
-        """
-        if self.conf.get('prefix') is None:
-            return key
-        else:
-            qualified_key = '{}{}'.format(self.conf['prefix'], key)
-            return qualified_key.lstrip('/')
-
     def _get(self, key):
         try:
-            return self.session.kv[self._qualified_key(key)]
+            return self.session.kv[key]
         except KeyError:
             return None
 
     def _set(self, key, value):
-        self.session.kv.set(self._qualified_key(key), value)
+        self.session.kv.set(key, value)
+
+    def _qualified_key(self, key):
+        """
+        Prepends the configured prefix to the key (if applicable).
+
+        For Consul we also lstrip any '/' chars from the prefixed key.
+
+        :param key: The unprefixed key.
+        :return: The key with any configured prefix prepended.
+        """
+        fq_key = super(Reader, self)._qualified_key(key)
+        return fq_key.lstrip('/')

--- a/simple_settings/dynamic_settings/consul_reader.py
+++ b/simple_settings/dynamic_settings/consul_reader.py
@@ -20,7 +20,8 @@ class Reader(BaseReader):
     _default_conf = {
         'host': consulate.DEFAULT_HOST,
         'port': consulate.DEFAULT_PORT,
-        'scheme': consulate.DEFAULT_SCHEME
+        'scheme': consulate.DEFAULT_SCHEME,
+        'prefix': ''
     }
 
     def __init__(self, conf):
@@ -34,11 +35,23 @@ class Reader(BaseReader):
             scheme=self.conf['scheme']
         )
 
+    def _qualified_key(self, key):
+        """
+        Prepends the prefix to the key (if applicable).
+
+        :param key: The unprefixed key.
+        :return: The qualifeid key.
+        """
+        if self.conf.get('prefix') is None:
+            return key
+        else:
+            return '{}{}'.format(self.conf['prefix'], key)
+
     def _get(self, key):
         try:
-            return self.session.kv[key]
+            return self.session.kv[self._qualified_key(key)]
         except KeyError:
             return None
 
     def _set(self, key, value):
-        self.session.kv.set(key, value)
+        self.session.kv.set(self._qualified_key(key), value)

--- a/simple_settings/dynamic_settings/consul_reader.py
+++ b/simple_settings/dynamic_settings/consul_reader.py
@@ -45,7 +45,8 @@ class Reader(BaseReader):
         if self.conf.get('prefix') is None:
             return key
         else:
-            return '{}{}'.format(self.conf['prefix'], key)
+            qualified_key = '{}{}'.format(self.conf['prefix'], key)
+            return qualified_key.lstrip('/')
 
     def _get(self, key):
         try:

--- a/tests/dynamic_settings/test_consul.py
+++ b/tests/dynamic_settings/test_consul.py
@@ -133,3 +133,20 @@ class TestDynamicConsulSettings(object):
 
         settings.configure(SIMPLE_STRING='foo')
         assert consul.get('test/SIMPLE_STRING') == 'foo'
+
+
+    def test_should_use_consul_reader_with_null_prefix_with_simple_settings(self, consul):
+        settings = LazySettings('tests.samples.simple')
+        settings.configure(
+            SIMPLE_SETTINGS={'DYNAMIC_SETTINGS': {'backend': 'consul', 'prefix': None}}
+        )
+        settings._initialized = False
+        settings.setup()
+
+        assert settings.SIMPLE_STRING == 'simple'
+
+        consul.set('SIMPLE_STRING', 'dynamic')
+        assert settings.SIMPLE_STRING == 'dynamic'
+
+        settings.configure(SIMPLE_STRING='foo')
+        assert consul.get('SIMPLE_STRING') == 'foo'

--- a/tests/dynamic_settings/test_consul.py
+++ b/tests/dynamic_settings/test_consul.py
@@ -117,3 +117,19 @@ class TestDynamicConsulSettings(object):
 
         settings.configure(SIMPLE_STRING='foo')
         assert consul.get('test/SIMPLE_STRING') == 'foo'
+
+    def test_should_use_consul_reader_with_leadingslash_prefix_with_simple_settings(self, consul):
+        settings = LazySettings('tests.samples.simple')
+        settings.configure(
+            SIMPLE_SETTINGS={'DYNAMIC_SETTINGS': {'backend': 'consul', 'prefix': '/test/'}}
+        )
+        settings._initialized = False
+        settings.setup()
+
+        assert settings.SIMPLE_STRING == 'simple'
+
+        consul.set('test/SIMPLE_STRING', 'dynamic')
+        assert settings.SIMPLE_STRING == 'dynamic'
+
+        settings.configure(SIMPLE_STRING='foo')
+        assert consul.get('test/SIMPLE_STRING') == 'foo'

--- a/tests/dynamic_settings/test_consul.py
+++ b/tests/dynamic_settings/test_consul.py
@@ -81,7 +81,7 @@ class TestDynamicConsulSettings(object):
 
     def test_should_set_string_in_consul_by_reader_with_prefix(self, consul, reader_with_prefix):
         key = 'SIMPLE_STRING'
-        expected_setting = 'simple from redis'
+        expected_setting = 'simple from consul'
         reader_with_prefix.set(key, expected_setting)
 
         assert consul.get('test/' + key) == expected_setting

--- a/tests/dynamic_settings/test_consul.py
+++ b/tests/dynamic_settings/test_consul.py
@@ -74,7 +74,7 @@ class TestDynamicConsulSettings(object):
 
     def test_should_set_string_in_consul_by_reader(self, consul, reader):
         key = 'SIMPLE_STRING'
-        expected_setting = 'simple from redis'
+        expected_setting = 'simple from consul'
         reader.set(key, expected_setting)
 
         assert consul.get(key) == expected_setting

--- a/tests/dynamic_settings/test_consul.py
+++ b/tests/dynamic_settings/test_consul.py
@@ -26,6 +26,15 @@ class TestDynamicConsulSettings(object):
             'SIMPLE_STRING': 'simple'
         }
 
+    @pytest.fixture
+    def settings_dict_to_override_by_consul_with_prefix(self):
+        return {
+            'SIMPLE_SETTINGS': {
+                'DYNAMIC_SETTINGS': {'backend': 'consul', 'prefix': 'test/'}
+            },
+            'SIMPLE_STRING': 'simple'
+        }
+
     @pytest.yield_fixture
     def consul(self):
         session = consulate.Consul()
@@ -38,6 +47,10 @@ class TestDynamicConsulSettings(object):
     @pytest.fixture
     def reader(self, settings_dict_to_override_by_consul):
         return get_dynamic_reader(settings_dict_to_override_by_consul)
+
+    @pytest.fixture
+    def reader_with_prefix(self, settings_dict_to_override_by_consul_with_prefix):
+        return get_dynamic_reader(settings_dict_to_override_by_consul_with_prefix)
 
     def test_should_return_an_instance_of_consul_reader(
         self, settings_dict_to_override_by_consul
@@ -52,12 +65,26 @@ class TestDynamicConsulSettings(object):
 
         assert reader.get(key) == expected_setting
 
+    def test_should_get_string_in_consul_by_reader_with_prefix(self, consul, reader_with_prefix):
+        key = 'SIMPLE_STRING'
+        expected_setting = 'simple from consul'
+        consul.set('test/' + key, expected_setting)
+
+        assert reader_with_prefix.get(key) == expected_setting
+
     def test_should_set_string_in_consul_by_reader(self, consul, reader):
         key = 'SIMPLE_STRING'
         expected_setting = 'simple from redis'
         reader.set(key, expected_setting)
 
         assert consul.get(key) == expected_setting
+
+    def test_should_set_string_in_consul_by_reader_with_prefix(self, consul, reader_with_prefix):
+        key = 'SIMPLE_STRING'
+        expected_setting = 'simple from redis'
+        reader_with_prefix.set(key, expected_setting)
+
+        assert consul.get('test/' + key) == expected_setting
 
     def test_should_use_consul_reader_with_simple_settings(self, consul):
         settings = LazySettings('tests.samples.simple')
@@ -74,3 +101,19 @@ class TestDynamicConsulSettings(object):
 
         settings.configure(SIMPLE_STRING='foo')
         assert consul.get('SIMPLE_STRING') == 'foo'
+
+    def test_should_use_consul_reader_with_prefix_with_simple_settings(self, consul):
+        settings = LazySettings('tests.samples.simple')
+        settings.configure(
+            SIMPLE_SETTINGS={'DYNAMIC_SETTINGS': {'backend': 'consul', 'prefix': 'test/'}}
+        )
+        settings._initialized = False
+        settings.setup()
+
+        assert settings.SIMPLE_STRING == 'simple'
+
+        consul.set('test/SIMPLE_STRING', 'dynamic')
+        assert settings.SIMPLE_STRING == 'dynamic'
+
+        settings.configure(SIMPLE_STRING='foo')
+        assert consul.get('test/SIMPLE_STRING') == 'foo'

--- a/tests/dynamic_settings/test_database.py
+++ b/tests/dynamic_settings/test_database.py
@@ -87,3 +87,25 @@ class TestDynamicDatabaseSettings(object):
 
         settings.configure(SIMPLE_STRING='foo')
         assert database.get('SIMPLE_STRING') == 'foo'
+
+    def test_should_use_database_reader_with_prefix_with_simple_settings(
+        self, database, sqlite_db
+    ):
+        settings = LazySettings('tests.samples.simple')
+        settings.configure(
+            SIMPLE_SETTINGS={'DYNAMIC_SETTINGS': {
+                'backend': 'database',
+                'sqlalchemy.url': sqlite_db,
+                'prefix': 'MYAPP_'
+            }}
+        )
+        settings._initialized = False
+        settings.setup()
+
+        assert settings.SIMPLE_STRING == 'simple'
+
+        database.set('MYAPP_SIMPLE_STRING', 'dynamic')
+        assert settings.SIMPLE_STRING == 'dynamic'
+
+        settings.configure(SIMPLE_STRING='foo')
+        assert database.get('MYAPP_SIMPLE_STRING') == 'foo'

--- a/tests/dynamic_settings/test_redis.py
+++ b/tests/dynamic_settings/test_redis.py
@@ -80,3 +80,19 @@ class TestDynamicRedisSettings(object):
 
         settings.configure(SIMPLE_STRING='foo')
         assert self._get_value_from_redis(redis, 'SIMPLE_STRING') == 'foo'
+
+    def test_should_use_redis_reader_with_prefix_with_simple_settings(self, redis):
+        settings = LazySettings('tests.samples.simple')
+        settings.configure(
+            SIMPLE_SETTINGS={'DYNAMIC_SETTINGS': {'backend': 'redis', 'prefix': 'MYAPP_'}}
+        )
+        settings._initialized = False
+        settings.setup()
+
+        assert settings.SIMPLE_STRING == 'simple'
+
+        redis.set('MYAPP_SIMPLE_STRING', 'dynamic')
+        assert settings.SIMPLE_STRING == 'dynamic'
+
+        settings.configure(SIMPLE_STRING='foo')
+        assert self._get_value_from_redis(redis, 'MYAPP_SIMPLE_STRING') == 'foo'


### PR DESCRIPTION
In our use case for Consul, we would like to be able to qualify the lookup keys with prefixes -- e.g. based on application name -- so that "SQLALCHEMY_URL" can be different for each of our different applications that share a single Consul configuration backend.

This Pull Req includes the code to support specifying a prefix and a couple of functional tests to validate that this works as desired.