### PR TITLE
base setup to use travis to deploy package to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,12 @@ after_success:
 services:
     - redis
     - docker
+
+deploy:
+  provider: pypi
+  user: drgarcia1986
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true
+    repo: drgarcia1986/simple-settings
+  skip_cleanup: true


### PR DESCRIPTION
Fix #48 

@drgarcia1986 basically:

- checkout this branch
- `gem install travis`
- `travis encrypt --add deploy.password 'your_pypi_password'`
- fix you pypi user
- :gloria: