### PR TITLE
check if return from dynamic reader is `not None`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,7 @@ tag_name = {new_version}
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:docs/index.md]
+[bumpversion:file:README.rst]
 search = ### [NEXT_RELEASE]
 replace = ### [{new_version}] - {now:%Y-%m-%d}
 

--- a/README.rst
+++ b/README.rst
@@ -488,6 +488,11 @@ Decorator example
 Changelog
 ---------
 
+[NEXT_RELEASE]
+~~~~~~~~~~~~~~~~~~~~~
+
+- Fix dynamic settings read behavior to ignore only ``None`` values and not ``zeros`` values ( `#68 <https://github.com/drgarcia1986/simple-settings/issues/68>`__)
+
 [0.12.0] - 2017-03-07
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -89,7 +89,7 @@ class LazySettings(object):
 
         if self._dynamic_reader:
             dynamic_result = self._dynamic_reader.get(attr)
-            if dynamic_result:
+            if dynamic_result is not None:
                 self._dict[attr] = dynamic_result
                 result = dynamic_result
 

--- a/tests/dynamic_settings/test_dynamic_settings.py
+++ b/tests/dynamic_settings/test_dynamic_settings.py
@@ -57,6 +57,20 @@ class TestDynamicSettings(object):
         settings._dynamic_reader.set('SIMPLE_STRING', 'dynamic')
         assert settings.SIMPLE_STRING == 'dynamic'
 
+    @pytest.mark.parametrize('value', (False, '', 0))
+    def test_should_return_a_zero_value_by_reader_value(
+        self, settings_dict, value
+    ):
+        settings = LazySettings('tests.samples.simple')
+        settings.configure(**settings_dict)
+        settings._initialized = False  # to load dynamic read
+        settings.setup()
+
+        assert settings.SIMPLE_STRING == 'simple'
+
+        settings._dynamic_reader.set('SIMPLE_STRING', value)
+        assert settings.SIMPLE_STRING == value
+
     def test_should_update_setting_by_last_reader_value(
         self, settings_dict, reader
     ):


### PR DESCRIPTION
fix #68 