### PR TITLE
fix TypeError when trying to read .yaml

### DIFF
--- a/simple_settings/strategies/python.py
+++ b/simple_settings/strategies/python.py
@@ -16,7 +16,7 @@ class SettingsLoadStrategyPython(object):
         try:
             importlib.import_module(file_name)
             return True
-        except ImportError:
+        except (ImportError, TypeError):
             return False
 
     @staticmethod


### PR DESCRIPTION
If you'll try to read .yaml file with relative path, for example,
'./settings/local_dev.yaml', than you'll receive an error:
`TypeError: the 'package' argument is required to perform a relative import for './settings/local_dev.yaml'`

Just handle this case.