### PR TITLE
Add `json.loads` as new required_settings_type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -379,6 +379,7 @@ types.
     - ``"int"`` - python's native integer type, parsed from a string using ``int(value)``
     - ``"float"`` - python's native float type, parsed from a string using ``float(value)``
     - ``"str"`` - python's native string type, not parsed from a string
+    - ``"json.loads"`` - Can be some types resulted of python's ``json.loads(value)`` function (e.g. dict: '{"foo": "bar"} -> {'foo': 'bar'}, int: '1' -> 1, bool: 'true' -> True, etc.)
 
 Dynamic Settings
 ~~~~~~~~~~~~~~~~
@@ -573,6 +574,10 @@ Decorator example
 
 Changelog
 ---------
+
+[NEXT_RELEASE]
+
+- ``json.loads`` as new ``REQUIRED_SETTINGS_TYPES``
 
 [0.15.0] - 2019-02-23
 ~~~~~~~~~~~~~~

--- a/simple_settings/special_settings.py
+++ b/simple_settings/special_settings.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import logging.config
 import os
 from collections import OrderedDict
@@ -49,7 +50,8 @@ SETTINGS_TYPES = {
     'bool': (bool, bool_parser),
     'float': (float, float),
     'int': (int, int),
-    'str': (str, str)
+    'str': (str, str),
+    'json.loads': (dict, json.loads)
 }
 
 

--- a/tests/test_special_settings.py
+++ b/tests/test_special_settings.py
@@ -62,10 +62,12 @@ class TestSpecialSettings(object):
                 'REQUIRED_SETTINGS_TYPES': {
                     'SIMPLE_INTEGER': 'int',
                     'SIMPLE_BOOL': 'bool',
+                    'SIMPLE_STR': 'json.loads',
                 }
             },
             'SIMPLE_INTEGER': 0.1,  # not an int and not a str so cannot parse
             'SIMPLE_BOOL': 'foo',  # not a bool and not parseable to a bool
+            'SIMPLE_STR': 'foo',  # not a valid value to perform json.loads
         }
 
     @pytest.fixture
@@ -87,6 +89,9 @@ class TestSpecialSettings(object):
                     'BOOL_PARSED_3': 'bool',
                     'BOOL_PARSED_4': 'bool',
                     'BOOL_PARSED_5': 'bool',
+                    'JSON_LOADS_PARSED_1': 'json.loads',
+                    'JSON_LOADS_PARSED_2': 'json.loads',
+                    'JSON_LOADS_PARSED_3': 'json.loads',
                 }
             },
             'STRING_NONE': None,
@@ -102,7 +107,10 @@ class TestSpecialSettings(object):
             'BOOL_PARSED_1': 'true',
             'BOOL_PARSED_3': 'True',
             'BOOL_PARSED_4': 'false',
-            'BOOL_PARSED_5': 'False'
+            'BOOL_PARSED_5': 'False',
+            'JSON_LOADS_PARSED_1': '{"simple": "value"}',
+            'JSON_LOADS_PARSED_2': 'true',
+            'JSON_LOADS_PARSED_3': '1',
         }
 
     @pytest.fixture
@@ -226,6 +234,13 @@ class TestSpecialSettings(object):
         assert isinstance(converted_value('BOOL_PARSED_3'), bool)
         assert isinstance(converted_value('BOOL_PARSED_4'), bool)
         assert isinstance(converted_value('BOOL_PARSED_5'), bool)
+        assert isinstance(converted_value('JSON_LOADS_PARSED_1'), dict)
+        assert isinstance(converted_value('JSON_LOADS_PARSED_2'), bool)
+        assert isinstance(converted_value('JSON_LOADS_PARSED_3'), int)
+
+        assert converted_value('JSON_LOADS_PARSED_1') == {'simple': 'value'}
+        assert converted_value('JSON_LOADS_PARSED_2') == True
+        assert converted_value('JSON_LOADS_PARSED_3') == 1
 
     def test_override_by_env_and_required_loads_in_correct_order(
         self, settings_dict_override_and_required


### PR DESCRIPTION
Useful to override complex settings from env, f.ex:

* settings file
```python

SIMPLE_CONF = {'simple': 'conf'}

SIMPLE_SETTINGS = {
    'OVERRIDE_BY_ENV': True,
    'REQUIRED_SETTINGS_TYPES': {
        'SIMPLE_CONF': 'json.loads',
    }
}
```
* app
```python
from simple_settings import settings

print(settings.SIMPLE_CONF)
```
* execution
```
$ python app.py
{'simple': 'conf'}

$ SIMPLE_CONF='{"from": "env"}' python app.py
{'from': 'env'}
```