### PR TITLE
allow the environment variables to be used as a virtual settings file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,6 +202,13 @@ The simple-settings is prepared to play with the following files types:
 
     For toml files is necessary to install with extras require *toml*, e.g.: ``pip install simple-settings[toml]``
 
+
+Loading settings from environment variables
+-------------------------------------------
+
+simple-settings can load all environment variables, e.g. ``python app.py --settings=.environ`` or only environment variables that start with a certain prefix, e.g. ``python app.py --settings=MYPREFIX_.environ``.
+
+
 Load multiple settings modules
 ------------------------------
 
@@ -211,10 +218,10 @@ example:
 
 .. code:: bash
 
-    $ python app.py --settings=production,amazon,new_relic
+    $ python app.py --settings=production,amazon,new_relic,PREFIX_.environ
 
 simple-setting will load all settings modules in order that was
-specified (``production``-> ``amazon`` -> ``new_relic``) overriding
+specified (``production``-> ``amazon`` -> ``new_relic`` -> ``PREFIX_.environ``) overriding
 possibles conflicts.
 
 This also works with *LazySettings* class:
@@ -224,7 +231,7 @@ This also works with *LazySettings* class:
     from simple_settings import LazySettings
 
 
-    settings = LazySettings('production', 'amazon', 'new_relic')
+    settings = LazySettings('production', 'amazon', 'new_relic', 'PREFIX_.environ')
 
 You can combine any type of settings (*python modules*, *yaml*, etc.).
 
@@ -578,15 +585,16 @@ Changelog
 [NEXT_RELEASE]
 ~~~~~~~~~~~~~~
 
+- Allow settings to be loaded from environment variables via ``.environ`` or ``PREFIX_.environ``
 - Using ``strtobool`` from standard library on ``Required Settings Type`` feature.
 
 [0.16.0] - 2019-02-23
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 - ``json.loads`` as new ``REQUIRED_SETTINGS_TYPES``
 
 [0.15.0] - 2019-02-23
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 - Enforce ordering of special settings being applied
 - Dynamic settings behaviors with ``memcached``.

--- a/simple_settings/strategies/__init__.py
+++ b/simple_settings/strategies/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from .cfg import SettingsLoadStrategyCfg
+from .environ import SettingsLoadStrategyEnviron
 from .json_file import SettingsLoadStrategyJson
 from .python import SettingsLoadStrategyPython
-from .environ import SettingsLoadStrategyEnviron
 
 yaml_strategy = None
 try:

--- a/simple_settings/strategies/__init__.py
+++ b/simple_settings/strategies/__init__.py
@@ -2,6 +2,7 @@
 from .cfg import SettingsLoadStrategyCfg
 from .json_file import SettingsLoadStrategyJson
 from .python import SettingsLoadStrategyPython
+from .environ import SettingsLoadStrategyEnviron
 
 yaml_strategy = None
 try:
@@ -21,7 +22,8 @@ except ImportError:  # pragma: no cover
 strategies = (
     SettingsLoadStrategyPython,
     SettingsLoadStrategyCfg,
-    SettingsLoadStrategyJson
+    SettingsLoadStrategyJson,
+    SettingsLoadStrategyEnviron
 )
 
 if yaml_strategy:

--- a/simple_settings/strategies/environ.py
+++ b/simple_settings/strategies/environ.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 
 
 class SettingsLoadStrategyEnviron(object):

--- a/simple_settings/strategies/environ.py
+++ b/simple_settings/strategies/environ.py
@@ -6,7 +6,7 @@ class SettingsLoadStrategyEnviron(object):
     """
     This is the strategy used to read settings from `os.environ`.
     `file_name` could be '.environ' to load all environment variables or
-    '`PREFIX`.environ' to load environment variables starting with `PREFIX`. 
+    '`PREFIX`.environ' to load environment variables starting with `PREFIX`.
     """
     name = 'environ'
 

--- a/simple_settings/strategies/environ.py
+++ b/simple_settings/strategies/environ.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+
+class SettingsLoadStrategyEnviron(object):
+    """
+    This is the strategy used to read settings from `os.environ`.
+    `file_name` could be '.environ' to load all environment variables or
+    '`PREFIX`.environ' to load environment variables starting with `PREFIX`. 
+    """
+    name = 'environ'
+
+    @staticmethod
+    def is_valid_file(file_name):
+        return file_name.endswith('.environ')
+
+    @staticmethod
+    def load_settings_file(settings_file):
+        env_prefix = settings_file.replace('.environ', '')
+        if env_prefix:
+            result = {}
+            for k, v in os.environ.items():
+                if k.startswith(env_prefix):
+                    result[k] = v
+        else:
+            result = os.environ.copy()
+        return result

--- a/simple_settings/strategies/environ.py
+++ b/simple_settings/strategies/environ.py
@@ -5,8 +5,8 @@ import os
 class SettingsLoadStrategyEnviron(object):
     """
     This is the strategy used to read settings from `os.environ`.
-    `file_name` could be '.environ' to load all environment variables or
-    '`PREFIX`.environ' to load environment variables starting with `PREFIX`.
+    If `file_name` is set to '.environ', it will load all environment variables.
+    If set to '`PREFIX`.environ', it will load environment variables starting with `PREFIX`.
     """
     name = 'environ'
 

--- a/simple_settings/strategies/environ.py
+++ b/simple_settings/strategies/environ.py
@@ -5,8 +5,9 @@ import os
 class SettingsLoadStrategyEnviron(object):
     """
     This is the strategy used to read settings from `os.environ`.
-    If `file_name` is set to '.environ', it will load all environment variables.
-    If set to '`PREFIX`.environ', it will load environment variables starting with `PREFIX`.
+    If `file_name`=='.environ', it will load all environment variables.
+    If `file_name`=='`PREFIX`.environ', it will load environment variables
+        starting with `PREFIX`.
     """
     name = 'environ'
 

--- a/tests/strategies/test_environ.py
+++ b/tests/strategies/test_environ.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import os
+import pytest
+
+from simple_settings.strategies.environ import SettingsLoadStrategyEnviron
+
+
+class TestEnvironStrategy(object):
+
+    @pytest.fixture
+    def strategy_environ(self):
+        return SettingsLoadStrategyEnviron
+
+    def test_should_check_a_valid_environ_file(self, strategy_environ):
+        assert strategy_environ.is_valid_file('foo.environ') is True
+
+    def test_should_check_a_invalid_environ_file(self, strategy_environ):
+        assert strategy_environ.is_valid_file('foo.bar') is False
+
+    def test_should_load_dict_with_settings_of_environ_file(self, strategy_environ):
+        settings = strategy_environ.load_settings_file(
+            '.environ'
+        )
+
+        for k, v in os.environ.items():
+            assert settings[k] == v
+
+    def test_should_load_dict_with_settings_of_prefixed_environ_file(self, strategy_environ):
+        os.environ.update(dict(
+            PREFIX_A='good',
+            PREFIX_13='great',
+            WRONG_PREFIX_XYZ='1',
+        ))
+        settings = strategy_environ.load_settings_file(
+            'PREFIX_.environ'
+        )
+
+        assert settings['PREFIX_A'] == 'good'
+        assert settings['PREFIX_13'] == 'great'
+
+        assert 'WRONG_PREFIX_XYZ' not in settings

--- a/tests/strategies/test_environ.py
+++ b/tests/strategies/test_environ.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+
 import pytest
 
 from simple_settings.strategies.environ import SettingsLoadStrategyEnviron


### PR DESCRIPTION
This PR allows the user to run the following use cases:

1. When we don't need to use a settings file -- the available environment variables suffice:

`python app.py --settings=.environ` 

This will load all existing environment variables.

2. Load only environment variables starting with a specific prefix:

`python app.py --settings=MYPREFIX_.environ` 

This will load all existing environment variables that starts with `MYPREFIX_`.

3. Have the flexibility to choose whether the environment variables override the settings files or vice versa:

`python app.py --settings=.environ,settings.development` 

`python app.py --settings=settings.development,.environ` 
