### PR TITLE
Allow ``LazySettings.strategies`` to be easily overridden.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -586,6 +586,7 @@ Changelog
 ~~~~~~~~~~~~~~
 
 - Allow settings to be loaded from environment variables via ``.environ`` or ``PREFIX_.environ``
+- Allow ``LazySettings.strategies`` to be easily overridden.
 - Using ``strtobool`` from standard library on ``Required Settings Type`` feature.
 
 [0.16.0] - 2019-02-23

--- a/README.rst
+++ b/README.rst
@@ -375,7 +375,7 @@ The supported types are listed below. If you attempt to set a type that is not
 one of these types, then a ``ValueError`` will be raised with any unsupported
 types.
 
-    - ``"bool"`` - python's native boolean type, parsed from a string as true if the value is ``"True"`` or ``"true"``; and as false if the value if ``"False"`` or ``"false"``
+    - ``"bool"`` - python's native boolean type, True values are ``y``, ``yes``, ``t``, ``true``, ``on`` and ``1``; false values are ``n``, ``no``, ``f``, ``false``, ``off`` and ``0``
     - ``"int"`` - python's native integer type, parsed from a string using ``int(value)``
     - ``"float"`` - python's native float type, parsed from a string using ``float(value)``
     - ``"str"`` - python's native string type, not parsed from a string
@@ -574,6 +574,11 @@ Decorator example
 
 Changelog
 ---------
+
+[NEXT_RELEASE]
+~~~~~~~~~~~~~~
+
+- Using ``strtobool`` from standard library on ``Required Settings Type`` feature.
 
 [0.16.0] - 2019-02-23
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -519,7 +519,7 @@ the ``DYNAMIC_SETTINGS`` special setting with the ``s3`` backend
 
 
 Memcached
-^^^^^^
+^^^^^^^^^
 
 You can read your settings dynamically with memcached if you activate
 the ``DYNAMIC_SETTINGS`` special setting with the ``memcached`` backend
@@ -578,6 +578,27 @@ Decorator example
 
     assert get_some_setting() == 'foo'
     assert settings.SOME_SETTING == 'bar'
+
+
+Advanced Usage
+--------------
+
+Custom Strategy
+~~~~~~~~~~~~~~~
+
+To implement a custom strategy:
+
+.. code:: python
+
+    from simple_settings import settings
+
+    class SettingsCustomStrategy(object):
+        """
+        See `/simple_settings/strategies` for sample strategies (e.g. python, json, cfg)
+        """
+
+    settings.add_strategy(SettingsCustomStrategy)
+
 
 Changelog
 ---------

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -26,6 +26,7 @@ class LazySettings(object):
         self._initialized = False
         self._dict = {}
         self._dynamic_reader = None
+        self.strategies = strategies
 
     def __repr__(self):
         return '<SIMPLE-SETTINGS ({})>'.format(self.as_dict())
@@ -73,9 +74,8 @@ class LazySettings(object):
             settings = strategy.load_settings_file(settings_file)
             self._dict.update(settings)
 
-    @staticmethod
-    def _get_strategy_by_file(settings_file):
-        for strategy in strategies:
+    def _get_strategy_by_file(self, settings_file):
+        for strategy in self.strategies:
             if strategy.is_valid_file(settings_file):
                 return strategy
         raise RuntimeError('Invalid settings file [{}]'.format(settings_file))

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -95,6 +95,9 @@ class LazySettings(object):
 
         return result
 
+    def add_strategy(self, strategy):
+        self.strategies += (strategy,)
+
     def configure(self, **settings):
         self.setup()
         self._dict.update(settings)

--- a/simple_settings/special_settings.py
+++ b/simple_settings/special_settings.py
@@ -3,6 +3,7 @@ import json
 import logging.config
 import os
 from collections import OrderedDict
+from distutils.util import strtobool
 
 from .constants import SPECIAL_SETTINGS_KEY
 
@@ -38,16 +39,8 @@ def required_not_none_settings(settings_dict):
         )
 
 
-def bool_parser(value):
-    if value.lower() == 'true':
-        return True
-    elif value.lower() == 'false':
-        return False
-    raise ValueError()
-
-
 SETTINGS_TYPES = {
-    'bool': (bool, bool_parser),
+    'bool': (bool, lambda x: bool(strtobool(x))),
     'float': (float, float),
     'int': (int, int),
     'str': (str, str),

--- a/tests/samples/python_obj.py
+++ b/tests/samples/python_obj.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+
+class MyConfig(object):
+    START_URLS = ['https://www.google.com']
+    AUTO_CONNECT = True
+
+
+def config_invalid():
+    START_URLS = ['https://www.google.com']
+    AUTO_CONNECT = True

--- a/tests/test_custom_strategy.py
+++ b/tests/test_custom_strategy.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import importlib
+import inspect
+
+import pytest
+
+from simple_settings.core import LazySettings
+
+
+class SettingsLoadStrategyPythonObj(object):
+    """
+    This is the strategy used to read settings from a python class' attributes.
+
+    this strategy ignores settings that contain lowercase characters.
+    """
+    name = 'python_obj'
+
+
+    @staticmethod
+    def _load_object(path):
+        """Load an object given its absolute object path, and return it.
+
+        object can be a class, function, variable or an instance.
+        path ie: 'simple_settings.core.LazySettings'
+        """
+
+        try:
+            dot = path.rindex('.')
+        except ValueError:
+            raise ValueError(
+                "Error loading object '%s': not a full path" % path)
+
+        module, name = path[:dot], path[dot + 1:]
+        mod = importlib.import_module(module)
+
+        try:
+            obj = getattr(mod, name)
+        except AttributeError:
+            raise NameError(
+                "Module '%s' doesn't define any object named '%s'" % (
+                module, name))
+
+        return obj
+
+    @staticmethod
+    def is_valid_file(file_name):
+        try:
+            obj = SettingsLoadStrategyPythonObj._load_object(file_name)
+            return inspect.isclass(obj)
+        except (ImportError, TypeError, ValueError, NameError):
+            return False
+
+    @staticmethod
+    def load_settings_file(settings_file):
+        result = {}
+        obj = SettingsLoadStrategyPythonObj._load_object(settings_file)
+        for k, v in getattr(obj, '__dict__').items():
+            if k[0].isupper():
+                result[k] = v
+        return result
+
+
+class TestSettingsCustomStrategy(object):
+
+    def test_should_read_class_settings_value(self):
+        settings = LazySettings('tests.samples.python_obj.MyConfig')
+        settings.add_strategy(SettingsLoadStrategyPythonObj)
+
+        assert settings.START_URLS == ['https://www.google.com']
+        assert settings.AUTO_CONNECT == True
+
+    def test_should_not_non_class_settings_value(self):
+        settings = LazySettings('tests.samples.python_obj.config_invalid')
+        settings.add_strategy(SettingsLoadStrategyPythonObj)
+
+        with pytest.raises(RuntimeError):
+            settings.as_dict()
+
+    def test_misconfigured_object_path(self):
+        settings = LazySettings('tests.samples.non_existing_module.Config')
+        settings.add_strategy(SettingsLoadStrategyPythonObj)
+
+        with pytest.raises(RuntimeError):
+            settings.as_dict()
+
+        settings = LazySettings('tests.samples.python_obj.non_existing_class')
+        settings.add_strategy(SettingsLoadStrategyPythonObj)
+
+        with pytest.raises(RuntimeError):
+            settings.as_dict()


### PR DESCRIPTION
To implement a custom strategy for a very specific use case in my app, I'm doing:

```
from simple_settings import LazySettings, settings
from simple_settings.strategies import strategies

class SettingsCustomStrategy(object):
    pass

strategies += (SettingsCustomStrategy,)


class LazySettingsExtended(LazySettings):
    @staticmethod
    def _get_strategy_by_file(settings_file):
        for strategy in strategies:
            if strategy.is_valid_file(settings_file):
                return strategy
        raise RuntimeError('Invalid settings file [{}]'.format(settings_file))

settings.__class__ = LazySettingsExtended
```

With this PR, it will be easier for an application to add a custom strategy for loading settings, e.g.:

```
from simple_settings import settings

class SettingsCustomStrategy(object):
    pass

settings.add_strategy(SettingsCustomStrategy)
```