### PR TITLE
Small fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -608,7 +608,7 @@ Changelog
 
 - Fix ``TypeError`` on ``jsonpickle.decode`` when `auto_casting` is True and
   dynamic backend returns None.
-- Log error containing ``settings_file`` information when an error occurs in
+- Raise error containing ``settings_file`` information when an error occurs in
   ``strategy.load_settings_file`` call from ``_load_settings_pipeline``.
 - If dynamic settings is enabled, query first the dynamic backend before
   raising an AttributeError.

--- a/README.rst
+++ b/README.rst
@@ -608,8 +608,8 @@ Changelog
 
 - Fix ``TypeError`` on ``jsonpickle.decode`` when `auto_casting` is True and
   dynamic backend returns None.
-- Raise error containing ``settings_file`` information when an error occurs in
-  ``strategy.load_settings_file`` call from ``_load_settings_pipeline``.
+- Raise exception containing ``settings_file`` information when an error occurs
+  in ``strategy.load_settings_file`` call from ``_load_settings_pipeline``.
 - If dynamic settings is enabled, query first the dynamic backend before
   raising an AttributeError.
 

--- a/README.rst
+++ b/README.rst
@@ -603,6 +603,16 @@ To implement a custom strategy:
 Changelog
 ---------
 
+[NEXT_RELEASE]
+~~~~~~~~~~~~~~
+
+- Fix ``TypeError`` on ``jsonpickle.decode`` when `auto_casting` is True and
+  dynamic backend returns None.
+- Log error containing ``settings_file`` information when an error occurs in
+  ``strategy.load_settings_file`` call from ``_load_settings_pipeline``.
+- If dynamic settings is enabled, query first the dynamic backend before
+  raising an AttributeError.
+
 [0.17.0] - 2019-07-10
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 import sys
 from copy import deepcopy
@@ -6,6 +7,8 @@ from copy import deepcopy
 from .dynamic_settings import get_dynamic_reader
 from .special_settings import process_special_settings
 from .strategies import strategies
+
+logger = logging.getLogger(__name__)
 
 
 class LazySettings(object):
@@ -74,9 +77,11 @@ class LazySettings(object):
             try:
                 settings = strategy.load_settings_file(settings_file)
             except Exception as e:
-                raise RuntimeError(
-                    'Error processing settings_file "{}"'.format(settings_file)
-                ) from e
+                logger.exception(
+                    'Error processing settings_file "{}":\n {}'.format(
+                        settings_file, e
+                    ))
+                raise
             else:
                 self._dict.update(settings)
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import logging
 import os
 import sys
 from copy import deepcopy
@@ -7,8 +6,6 @@ from copy import deepcopy
 from .dynamic_settings import get_dynamic_reader
 from .special_settings import process_special_settings
 from .strategies import strategies
-
-logger = logging.getLogger(__name__)
 
 
 class LazySettings(object):
@@ -77,10 +74,9 @@ class LazySettings(object):
             try:
                 settings = strategy.load_settings_file(settings_file)
             except Exception as e:
-                logger.error(
-                    'Error processing settings_file "{}":\n {}'.format(
-                        settings_file, e
-                    ), exc_info=True)
+                raise RuntimeError(
+                    'Error processing settings_file "{}"'.format(settings_file)
+                ) from e
             else:
                 self._dict.update(settings)
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -71,8 +71,14 @@ class LazySettings(object):
     def _load_settings_pipeline(self):
         for settings_file in self._settings_list:
             strategy = self._get_strategy_by_file(settings_file)
-            settings = strategy.load_settings_file(settings_file)
-            self._dict.update(settings)
+            try:
+                settings = strategy.load_settings_file(settings_file)
+            except Exception:
+                print('Error processing settings_file: {}'.format(
+                    settings_file))
+                raise
+            else:
+                self._dict.update(settings)
 
     def _get_strategy_by_file(self, settings_file):
         for strategy in self.strategies:

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 import sys
 from copy import deepcopy
@@ -6,6 +7,9 @@ from copy import deepcopy
 from .dynamic_settings import get_dynamic_reader
 from .special_settings import process_special_settings
 from .strategies import strategies
+
+
+logger = logging.getLogger(__name__)
 
 
 class LazySettings(object):
@@ -73,10 +77,10 @@ class LazySettings(object):
             strategy = self._get_strategy_by_file(settings_file)
             try:
                 settings = strategy.load_settings_file(settings_file)
-            except Exception:
-                print('Error processing settings_file: {}'.format(
-                    settings_file))
-                raise
+            except Exception as e:
+                logger.error('Error processing settings_file "{}":\n {}'.format(
+                    settings_file, e
+                ), exc_info=True)
             else:
                 self._dict.update(settings)
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -88,18 +88,15 @@ class LazySettings(object):
 
     def __getattr__(self, attr):
         self.setup()
-        try:
-            result = self._dict[attr]
-        except KeyError:
-            raise AttributeError('You did not set {} setting'.format(attr))
-
         if self._dynamic_reader:
             dynamic_result = self._dynamic_reader.get(attr)
             if dynamic_result is not None:
                 self._dict[attr] = dynamic_result
-                result = dynamic_result
-
-        return result
+                return dynamic_result
+        try:
+            return self._dict[attr]
+        except KeyError:
+            raise AttributeError('You did not set {} setting'.format(attr))
 
     def add_strategy(self, strategy):
         self.strategies += (strategy,)

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -8,7 +8,6 @@ from .dynamic_settings import get_dynamic_reader
 from .special_settings import process_special_settings
 from .strategies import strategies
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/simple_settings/core.py
+++ b/simple_settings/core.py
@@ -78,9 +78,10 @@ class LazySettings(object):
             try:
                 settings = strategy.load_settings_file(settings_file)
             except Exception as e:
-                logger.error('Error processing settings_file "{}":\n {}'.format(
-                    settings_file, e
-                ), exc_info=True)
+                logger.error(
+                    'Error processing settings_file "{}":\n {}'.format(
+                        settings_file, e
+                    ), exc_info=True)
             else:
                 self._dict.update(settings)
 

--- a/simple_settings/dynamic_settings/base.py
+++ b/simple_settings/dynamic_settings/base.py
@@ -22,7 +22,7 @@ class BaseReader(object):
         if not self._is_valid_key(key):
             return
         result = self._get(self._qualified_key(key))
-        if self.auto_casting:
+        if self.auto_casting and (result is not None):
             result = jsonpickle.decode(result)
         return result
 

--- a/tests/dynamic_settings/test_dynamic_settings.py
+++ b/tests/dynamic_settings/test_dynamic_settings.py
@@ -155,4 +155,4 @@ class TestDynamicSettings(object):
         key = 'NON-EXISTING-KEY'
         reader.auto_casting = True
 
-        assert reader.get(key) == None
+        assert reader.get(key) is None

--- a/tests/dynamic_settings/test_dynamic_settings.py
+++ b/tests/dynamic_settings/test_dynamic_settings.py
@@ -148,3 +148,11 @@ class TestDynamicSettings(object):
         assert reader.get(key) == expected_setting
 
         assert reader._dict['COMPLEX'] != expected_setting
+
+    def test_should_get_none_when_auto_casting_for_unknown_key_dynamic_storage(
+        self, settings_dict, reader
+    ):
+        key = 'NON-EXISTING-KEY'
+        reader.auto_casting = True
+
+        assert reader.get(key) == None

--- a/tests/samples/invalid_toml_file.toml
+++ b/tests/samples/invalid_toml_file.toml
@@ -1,0 +1,10 @@
+ERROR_STRING = "\simple"
+SIMPLE_INTEGER = 1
+
+SIMPLE_BOOL = true
+
+COMPLEX_LIST = ["foo", "bar"]
+
+[COMPLEX_DICT]
+complex = "dict"
+foo = "bar"

--- a/tests/strategies/test_toml.py
+++ b/tests/strategies/test_toml.py
@@ -31,3 +31,9 @@ class TestTomlStrategy(object):
         assert settings['COMPLEX_LIST'] == ['foo', 'bar']
         assert settings['SIMPLE_INTEGER'] == 1
         assert settings['SIMPLE_BOOL'] is True
+
+    def test_should_raise_error_invalid_toml_file_content(self, strategy_toml):
+        with pytest.raises(Exception):
+            settings = strategy_toml.load_settings_file(
+                'tests/samples/invalid_toml_file.toml'
+            )

--- a/tests/test_custom_strategy.py
+++ b/tests/test_custom_strategy.py
@@ -69,7 +69,7 @@ class TestSettingsCustomStrategy(object):
         assert settings.START_URLS == ['https://www.google.com']
         assert settings.AUTO_CONNECT == True
 
-    def test_should_not_non_class_settings_value(self):
+    def test_should_not_read_non_class_settings_value(self):
         settings = LazySettings('tests.samples.python_obj.config_invalid')
         settings.add_strategy(SettingsLoadStrategyPythonObj)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -116,15 +116,11 @@ class TestSettings(object):
 
         assert settings.SIMPLE_INTEGER == 2
 
-    def test_should_log_error_on_invalid_settings_file_content(self):
-        with patch('logging.Logger.error') as mock:
+    def test_should_raise_error_msg_on_invalid_settings_file_content(self):
+        with pytest.raises(RuntimeError):
             settings = get_settings_by_cmd_line(
                 'tests/samples/invalid_toml_file.toml'
             )
-            mock.assert_called_with(
-                'Error processing settings_file '
-                '"tests/samples/invalid_toml_file.toml":'
-                '\n Reserved escape sequence used', exc_info=True)
 
     def test_should_load_a_complex_module_settings(self):
         settings = get_settings_by_cmd_line('tests.samples.complex')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -116,6 +116,16 @@ class TestSettings(object):
 
         assert settings.SIMPLE_INTEGER == 2
 
+    def test_should_log_error_on_invalid_settings_file_content(self):
+        with patch('logging.Logger.error') as mock:
+            settings = get_settings_by_cmd_line(
+                'tests/samples/invalid_toml_file.toml'
+            )
+            mock.assert_called_with(
+                'Error processing settings_file '
+                '"tests/samples/invalid_toml_file.toml":'
+                '\n Reserved escape sequence used', exc_info=True)
+
     def test_should_load_a_complex_module_settings(self):
         settings = get_settings_by_cmd_line('tests.samples.complex')
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -116,8 +116,8 @@ class TestSettings(object):
 
         assert settings.SIMPLE_INTEGER == 2
 
-    def test_should_raise_error_msg_on_invalid_settings_file_content(self):
-        with pytest.raises(RuntimeError):
+    def test_should_raise_error_on_invalid_settings_file_content(self):
+        with pytest.raises(Exception):
             settings = get_settings_by_cmd_line(
                 'tests/samples/invalid_toml_file.toml'
             )


### PR DESCRIPTION
some small fixes that might make sense :)
- **fix `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`**: this occurs when there is no data for the given key in the backend and `auto_casting` is enabled, causing `jsonpickle.decode` to fail.

- **on exception, print out the settings_file to help debugging**: when there are multiple settings_file, especially toml, it's hard to know which file is causing the problem without this fix.

- **if dynamic settings is enabled, query first the db before raising an AttributeError**: without this fix, the DB is not queried for keys that are not in the `_dict`.. Not sure if this is your intended behaviour.