### PR TITLE
Remove deprecated information about special settings on readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,9 +267,6 @@ a ``SIMPLE_SETTINGS`` dict in the settings module.
         }
     }
 
-*Note: special settings may only be specified in python settings files
-(not ini, yaml, etc.).*
-
 Configure logging
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Thanks @JonathanHuot
special settings configuration works fine with json, yaml or toml settings file.
fix #72